### PR TITLE
Move colon next to previous word

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ProtoDef
 
-ProtoDef specification : describe your protocol, and read it with ease.
+ProtoDef specification: describe your protocol, and read it with ease.
 
 ## Implementations
 


### PR DESCRIPTION
Maybe change this in the description as well. It's just common English style.