### PR TITLE
Add "variables"

### DIFF
--- a/doc/datatypes/conditional.md
+++ b/doc/datatypes/conditional.md
@@ -10,6 +10,10 @@ Arguments:
 switch make it possible to choose a datatype depending on the value of an other field. 
 It is similar to the switch/case syntax.
 
+For `compareTo` variables, to go up one level when referencing a field, use "../".
+
+Switch statement field names starting with "/" will reference a root variable. Root variables are primitives that can be used for comparisons and changed dynamically.
+
 Example:
 
 A switch which can encode a byte, a varint, a float or a string depending on "someField". 

--- a/schemas/conditional.json
+++ b/schemas/conditional.json
@@ -18,7 +18,7 @@
           "fields": {
             "type": "object",
             "patternProperties": {
-              "^[-a-zA-Z0-9 _:]+$": {
+              "^[-a-zA-Z0-9 _:/]+$": {
                 "$ref": "dataType"
               }
             },

--- a/test/conditional.json
+++ b/test/conditional.json
@@ -43,6 +43,15 @@
             "buffer":["0x02","0xff","0xff","0xfc","0x00"]
           }
         ]
+      },
+      {
+        "description": "container with a variable",
+        "vars": [["colorTransparent", 3]],
+        "type": [ "container", [ { "name": "color", "type": "i32" }, { "name": "opacity", "type": [ "switch", { "compareTo": "color", "fields": { "/colorTransparent": "void" }, "default": "u8" } ] } ] ],
+        "values": [
+          { "description": "active", "value": { "color": 3, "opacity": "undefined" }, "buffer": ["0x00","0x00","0x00","0x03"] },
+          { "description": "inactive", "value": { "color": 2, "opacity": 4 }, "buffer": ["0x00","0x00","0x00","0x02", "0x04"] }
+        ]
       }
     ]
   },

--- a/test/datatype_tests_schema.json
+++ b/test/datatype_tests_schema.json
@@ -16,7 +16,8 @@
         "type": {
           "type": "string"
         },
-        "values": {"$ref" : "#/definitions/test_values"}
+        "values": {"$ref" : "#/definitions/test_values"},
+        "vars": { "type": ["array"] }
       },
       "required": [
         "type",

--- a/test/datatype_tests_schema.json
+++ b/test/datatype_tests_schema.json
@@ -16,8 +16,7 @@
         "type": {
           "type": "string"
         },
-        "values": {"$ref" : "#/definitions/test_values"},
-        "vars": { "type": ["array"] }
+        "values": {"$ref" : "#/definitions/test_values"}
       },
       "required": [
         "type",
@@ -41,6 +40,7 @@
               "description":{
                 "type":"string"
               },
+              "vars": { "type": "array" },
               "type": {
                 "type": ["object","array"]
               },
@@ -71,6 +71,7 @@
           "description": {
             "type":"string"
           },
+          "vars": { "type": "array" },
           "value": {
             "type":[ "array", "boolean", "integer", "null", "number", "object", "string" ]
           },


### PR DESCRIPTION
Switch statement field names starting with "/" will reference a root variable, primitives that can be used for comparisons and changed dynamically.