### PR TITLE
Add docs for new varint and bitflags types

### DIFF
--- a/doc/datatypes/numeric.md
+++ b/doc/datatypes/numeric.md
@@ -61,5 +61,4 @@ Similar to **varint**, except using [ZigZag encoding](https://protobuf.dev/progr
 ### **zigzag64** ()
 Arguments: None
 
-Same as **zigzag32**, but for 64-bit signed integers.
-
+Same as **zigzag32**, but for 64-bit signed integers in ZigZag encoding.

--- a/doc/datatypes/numeric.md
+++ b/doc/datatypes/numeric.md
@@ -17,6 +17,7 @@ They default to big-endian encoding. To use little-endian, prefix its name with 
 | u64     | 8             | 1                   | unsigned long                |
 | varint  | 1-4           | 300                 | int var                      |
 | varint64 | 1-8           | 300n                | unsigned long                |
+| varint128 | 1-16         | 2 ^ 68              | unsigned __int128            |
 | zigzag32 | 1-4           | -100                | signed int var               |
 | zigzag64 | 1-8           | -680n               | signed long                  |
 
@@ -46,6 +47,11 @@ Example of value: `300` (size is 2 bytes)
 Arguments: None
 
 Same as **varint**, but for 64-bit unsigned integers, or signed 64-bit integers that have been directly cast to an integer (where the MSB is the sign bit) before encoding.
+
+### **varint128** ()
+Arguments: None
+
+Same as **varint**, but for 128-bit unsigned integers, or signed 128-bit integers that have been directly cast to an integer (where the MSB is the sign bit) before encoding.
 
 ### **zigzag32** ()
 Arguments: None

--- a/doc/datatypes/numeric.md
+++ b/doc/datatypes/numeric.md
@@ -15,7 +15,10 @@ They default to big-endian encoding. To use little-endian, prefix its name with 
 | f64     | 8             | 4.5                 | double                       |
 | i64     | 8             | 1                   | long                         |
 | u64     | 8             | 1                   | unsigned long                |
-| varint  | (varies)      | 300                 | int var                      |
+| varint  | 1-4           | 300                 | int var                      |
+| varint64 | 1-8           | 300n                | unsigned long                |
+| zigzag32 | 1-4           | -100                | signed int var               |
+| zigzag64 | 1-8           | -680n               | signed long                  |
 
 ### **int** ({ size: Integer })
 Arguments:
@@ -35,6 +38,22 @@ Example of value: `65535` (size = 2) / `16777215` (size = 3)
 ### **varint** ( )
 Arguments: None
 
-[Protobuf](https://developers.google.com/protocol-buffers/docs/encoding#varints)-compatible representation for variable-length integers using one or more bytes.
+[Protobuf](https://developers.google.com/protocol-buffers/docs/encoding#varints)-compatible representation for variable-length integers using one or more bytes. Intended for 32-bit unsigned integers, or signed 32-bit integers that have been directly cast to an integer (where the MSB is the sign bit) before encoding.
 
 Example of value: `300` (size is 2 bytes)
+
+### **varint64** ()
+Arguments: None
+
+Same as **varint**, but for 64-bit unsigned integers, or signed 64-bit integers that have been directly cast to an integer (where the MSB is the sign bit) before encoding.
+
+### **zigzag32** ()
+Arguments: None
+
+Similar to **varint**, except using [ZigZag encoding](https://protobuf.dev/programming-guides/encoding/#signed-ints) for signed integers. Intended for 32-bit signed numbers.
+
+### **zigzag64** ()
+Arguments: None
+
+Same as **zigzag32**, but for 64-bit signed integers.
+

--- a/doc/datatypes/utils.md
+++ b/doc/datatypes/utils.md
@@ -75,7 +75,7 @@ Arguments:
 * type : The underlying integer type (eg varint, lu32).
 * flags : Either an array of flag values from LSB to MSB, or an object containing a mappng of valueName => bitMask.
 * big : 64+ bits. In langauges like javascript (where all numbers are 64-bit floating points), special data types may have to be used for integers greater than 32 bits, so this must be set to true if the `type` is using the special data type.
-* shift : If flags is an array, an extra offset to add on. Helpful if there are unused bits at the LSB.
+* shift : Specify if flags is an object and holds bit positions as values opposed to a bitmask.
 
 Represents boolean flags packed into an integer. Similar to bitfields, but only intended for enumerated boolean flags (each flag occupies 1 bit), and supports arbitrary underlying integer types.
 
@@ -108,31 +108,6 @@ or
 
 Example of value to pass when writing: `{"flags": { "onGround": true, "inAir": false } }`. Likewise when reading you will get a similar object back, with a extra `_value` field holding the raw integer.
 
-### **mapper** ({ type: Type, mappings: { [String]: Any, ... } })
-Arguments:
-* type : the type of the input
-* mappings : a mappings object
-
-Maps string to a values.
-
-Example:
-
-Maps a byte to a string, 1 to "byte", 2 to "short", 3 to "int", 4 to "long".
-```json
-[
-  "mapper",
-  {
-    "type": "i8",
-    "mappings": {
-      "1": "byte",
-      "2": "short",
-      "3": "int",
-      "4": "long"
-    }
-  }
-]
-```
-Example of value: `"int"`
 
 ### **pstring** ({ countType: Type, ?count: Countable })
 Arguments:

--- a/doc/datatypes/utils.md
+++ b/doc/datatypes/utils.md
@@ -70,6 +70,70 @@ Maps a byte to a string, 1 to "byte", 2 to "short", 3 to "int", 4 to "long".
 ```
 Example of value: `"int"`
 
+### **bitflags** ([ { type: string, flags: object | array, big?: boolean, shift?: number } ])
+Arguments:
+* type : The underlying integer type (eg varint, lu32).
+* flags : Either an array of flag values from LSB to MSB, or an object containing a mappng of valueName => bitMask.
+* big : 64+ bits. In langauges like javascript (where all numbers are 64-bit floating points), special data types may have to be used for integers greater than 32 bits, so this must be set to true if the `type` is using the special data type.
+* shift : If flags is an array, an extra offset to add on. Helpful if there are unused bits at the LSB.
+
+Represents boolean flags packed into an integer. Similar to bitfields, but only intended for enumerated boolean flags (each flag occupies 1 bit), and supports arbitrary underlying integer types.
+
+Example:
+
+```json
+[
+  "bitflags",
+  {
+    "type": "lu32",
+    "flags": ["onGround", "inAir"]
+  }
+]
+```
+
+or 
+```yaml
+[
+  "bitflags",
+  {
+    "type": "lu32",
+    "big": true,
+    "flags": {
+      "onGround": 0b1,
+      "inAir": 0b10
+    }
+  }
+]
+```
+
+Example of value to pass when writing: `{"flags": { "onGround": true, "inAir": false } }`. Likewise when reading you will get a similar object back, with a extra `_value` field holding the raw integer.
+
+### **mapper** ({ type: Type, mappings: { [String]: Any, ... } })
+Arguments:
+* type : the type of the input
+* mappings : a mappings object
+
+Maps string to a values.
+
+Example:
+
+Maps a byte to a string, 1 to "byte", 2 to "short", 3 to "int", 4 to "long".
+```json
+[
+  "mapper",
+  {
+    "type": "i8",
+    "mappings": {
+      "1": "byte",
+      "2": "short",
+      "3": "int",
+      "4": "long"
+    }
+  }
+]
+```
+Example of value: `"int"`
+
 ### **pstring** ({ countType: Type, ?count: Countable })
 Arguments:
 * countType : the type of the length prefix

--- a/schemas/datatype.json
+++ b/schemas/datatype.json
@@ -27,6 +27,10 @@
     { "$ref": "lu64" },
     { "$ref": "int" },
     { "$ref": "varint" },
+    { "$ref": "varint64" },
+    { "$ref": "varint128" },
+    { "$ref": "zigzag32" },
+    { "$ref": "zigzag64" },
     { "$ref": "lint" },
 
     { "$ref": "array" },
@@ -40,6 +44,7 @@
     { "$ref": "pstring" },
     { "$ref": "buffer" },
     { "$ref": "bitfield" },
+    { "$ref": "bitflags" },
     { "$ref": "mapper" }
   ]
 }

--- a/schemas/numeric.json
+++ b/schemas/numeric.json
@@ -62,6 +62,18 @@
   "varint": {
     "enum": ["varint"]
   },
+  "varint64": {
+    "enum": ["varint64"]
+  },
+  "varint128": {
+    "enum": ["varint128"]
+  },
+  "zigzag32": {
+    "enum": ["zigzag32"]
+  },
+  "zigzag64": {
+    "enum": ["zigzag64"]
+  },
   "int": {
     "title": "int",
     "type": "array",

--- a/schemas/utils.json
+++ b/schemas/utils.json
@@ -102,6 +102,20 @@
     ],
     "additionalItems": false
   },
+  "bitflags": {
+    "title": "bitflags",
+    "type": "array",
+    "items": [
+      {
+        "enum": ["bitflags"]
+      },
+      {
+        "type": "object",
+        "additionalItems": false
+      }
+    ],
+    "additionalItems": false
+  },
   "mapper": {
     "title": "mapper",
     "type": "array",

--- a/test/utils.json
+++ b/test/utils.json
@@ -419,12 +419,12 @@
     ]
   },
   {
-    "type":"bitfield",
+    "type":"bitflags",
     "subtypes":[
       {
         "description":"8bit bitset flag array",
         "type":[
-          "bitfield",
+          "bitflags",
           { "type": "u8", "flags": ["onGround"] }
         ],
         "values":[
@@ -441,7 +441,7 @@
       {
         "description":"8bit bitset flag with object",
         "type":[
-          "bitfield",
+          "bitflags",
           { "type": "u8", "flags": { "onGround": 1 } }
         ],
         "values":[

--- a/test/utils.json
+++ b/test/utils.json
@@ -429,29 +429,43 @@
         ],
         "values":[
           {
-            "buffer":[
-              "0x1"
-            ],
             "value":{
+              "_value": 1,
               "onGround": true
-            }
+            },
+            "buffer":["0x01"]
           }
         ]
       },
       {
-        "description":"8bit bitset flag with object",
+        "description":"8bit bitset flag object",
         "type":[
           "bitflags",
           { "type": "u8", "flags": { "onGround": 1 } }
         ],
         "values":[
           {
-            "buffer":[
-              "0x1"
-            ],
             "value":{
+              "_value": 1,
               "onGround": true
-            }
+            },
+            "buffer":["0x01"]
+          }
+        ]
+      },
+      {
+        "description":"8bit bitset flag big object",
+        "type":[
+          "bitflags",
+          { "type": "u8", "big": true, "flags": { "onGround": 1 } }
+        ],
+        "values":[
+          {
+            "value":{
+              "_value": 1,
+              "onGround": true
+            },
+            "buffer":["0x01"]
           }
         ]
       }

--- a/test/utils.json
+++ b/test/utils.json
@@ -52,14 +52,94 @@
         "buffer":["0xff", "0xff", "0xff", "0xff", "0x0f"]
       },
       {
-        "description":"maximum varint",
+        "description":"maximum varint (32bit)",
         "value":2147483647,
         "buffer":["0xff", "0xff", "0xff", "0xff", "0x07"]
       },
       {
-        "description":"minimum varint",
+        "description":"minimum varint (32bit)",
         "value":-2147483648,
         "buffer":["0x80", "0x80", "0x80", "0x80", "0x08"]
+      }
+    ]
+  },
+  {
+    "type":"varint64",
+    "values":[
+      {
+        "description":"8-bit integer",
+        "value":1,
+        "buffer":["0x01"]
+      },
+      {
+        "description":"8-bit maximum integer",
+        "value":127,
+        "buffer":["0x7f"]
+      },
+      {
+        "description":"16-bit integer",
+        "value":300,
+        "buffer":["0xac", "0x02"]
+      },
+      {
+        "description":"24-bit integer",
+        "value":100000,
+        "buffer":["0xa0", "0x8d", "0x06"]
+      },
+      {
+        "description":"32-bit integer",
+        "value":16909060,
+        "buffer":["0x84", "0x86", "0x88", "0x08"]
+      }
+    ]
+  },
+  {
+    "type":"varint128",
+    "values":[
+      {
+        "description":"8-bit integer",
+        "value":1,
+        "buffer":["0x01"]
+      },
+      {
+        "description":"8-bit maximum integer",
+        "value":127,
+        "buffer":["0x7f"]
+      },
+      {
+        "description":"16-bit integer",
+        "value":300,
+        "buffer":["0xac", "0x02"]
+      },
+      {
+        "description":"24-bit integer",
+        "value":100000,
+        "buffer":["0xa0", "0x8d", "0x06"]
+      },
+      {
+        "description":"32-bit integer",
+        "value":16909060,
+        "buffer":["0x84", "0x86", "0x88", "0x08"]
+      }
+    ]
+  },
+  {
+    "type":"zigzag32",
+    "values":[
+      {
+        "description":"8-bit integer",
+        "value":1,
+        "buffer":["0x02"]
+      }
+    ]
+  },
+  {
+    "type":"zigzag64",
+    "values":[
+      {
+        "description":"8-bit integer",
+        "value":1,
+        "buffer":["0x02"]
       }
     ]
   },
@@ -333,6 +413,45 @@
               "0x65"
             ],
             "value":{ "x": 12, "y": 332, "z": 4382821 }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type":"bitfield",
+    "subtypes":[
+      {
+        "description":"8bit bitset flag array",
+        "type":[
+          "bitfield",
+          { "type": "u8", "flags": ["onGround"] }
+        ],
+        "values":[
+          {
+            "buffer":[
+              "0x1"
+            ],
+            "value":{
+              "onGround": true
+            }
+          }
+        ]
+      },
+      {
+        "description":"8bit bitset flag with object",
+        "type":[
+          "bitfield",
+          { "type": "u8", "flags": { "onGround": 1 } }
+        ],
+        "values":[
+          {
+            "buffer":[
+              "0x1"
+            ],
+            "value":{
+              "onGround": true
+            }
           }
         ]
       }


### PR DESCRIPTION
Moving the varint and bitflags types into protodef. Related:

https://github.com/PrismarineJS/bedrock-protocol/pull/552
https://github.com/PrismarineJS/node-minecraft-protocol/pull/1355
https://github.com/PrismarineJS/prismarine-nbt/pull/120