### PR TITLE
Fix/int schema size not in array

### DIFF
--- a/schemas/numeric.json
+++ b/schemas/numeric.json
@@ -82,18 +82,14 @@
         "enum": ["int"]
       },
       {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "size": {
-              "type": "number"
-            }
-          },
-          "required": ["size"],
-          "additionalProperties": false
+        "type": "object",
+        "properties": {
+          "size": {
+            "type": "number"
+          }
         },
-        "additionalItems": false
+        "required": ["size"],
+        "additionalProperties": false
       }
     ],
     "additionalItems": false
@@ -106,18 +102,14 @@
         "enum": ["lint"]
       },
       {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "size": {
-              "type": "number"
-            }
-          },
-          "required": ["size"],
-          "additionalProperties": false
+        "type": "object",
+        "properties": {
+          "size": {
+            "type": "number"
+          }
         },
-        "additionalItems": false
+        "required": ["size"],
+        "additionalProperties": false
       }
     ],
     "additionalItems": false


### PR DESCRIPTION
this brings the "numeric" schemas in line with the documentation. the schemas appear to require an extraneous object-nesting.

```json
["int", [{"size":3}]]
```
is validated by old schema.

```json
["int", {"size":3}]
```
is validated by new schema.